### PR TITLE
Fix routing for Contao 4.13

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,4 +1,0 @@
-# config/routes.yaml
-markocupic_contao_altcha_antispam.controller:
-    resource: ../src/Controller
-    type: attribute

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -42,8 +42,8 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
     public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)
     {
         return $resolver
-            ->resolve(__DIR__.'/../../config/routes.yaml')
-            ->load(__DIR__.'/../../config/routes.yaml')
-    ;
+            ->resolve(__DIR__.'/../Controller')
+            ->load(__DIR__.'/../Controller')
+        ;
     }
 }

--- a/src/Controller/AltchaController.php
+++ b/src/Controller/AltchaController.php
@@ -20,7 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
-#[Route('/_contao_altcha_challenge', name: self::class)]
+#[Route(path: '/_contao_altcha_challenge', name: self::class)]
 class AltchaController extends AbstractController
 {
     public function __construct(


### PR DESCRIPTION
In Contao 4.13 the following error occurs due to f6012c850d62c3771940fe18b687aacccb6666b8 which was released yesterday.

```
Cannot load resource "../src/Controller". Make sure there is a loader supporting the "attribute" type.
```

In Symfony 5 (Contao 4.13) the type needs to be `annotation`, even for PHP attributes. The `attribute` type is not supported there yet - it's only supported since Symfony 6 (Contao 5). And in Symfony 7 (installable since Contao 5.4) the type `annotation` is not supported anymore. To keep compatibility with Contao 4.13, Contao 5.3 and Contao 5.4+ this PR simply lets the loader autodetect the type by not specifying one.