### PR TITLE
Fix compatibility with Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,14 @@
     "require": {
         "php": "^8.1",
         "contao/core-bundle": "^4.13 || ^5.0",
-        "markocupic/contao-twig-assets": "^1.0"
+        "markocupic/contao-twig-assets": "^1.0",
+        "symfony/config": "^5.4 || ^6.4 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-foundation": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
+        "symfony/routing": "^5.4 || ^6.4 || ^7.0",
+        "symfony/security-core": "^5.4 || ^6.4 || ^7.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.12",

--- a/src/DataContainer/FormField.php
+++ b/src/DataContainer/FormField.php
@@ -20,7 +20,7 @@ use Contao\DataContainer;
 use Contao\Message;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FormField
@@ -28,7 +28,7 @@ class FormField
     public function __construct(
         private readonly Connection $connection,
         private readonly ContaoFramework $framework,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly TranslatorInterface $translator,
         private readonly string $altchaHmacKey,
     ) {
@@ -37,7 +37,7 @@ class FormField
     #[AsCallback(table: 'tl_form_field', target: 'config.onload', priority: 100)]
     public function displayMessage(DataContainer $dc): void
     {
-        if (!$this->security->isGranted('ROLE_ADMIN')) {
+        if (!$this->authorizationChecker->isGranted('ROLE_ADMIN')) {
             return;
         }
 


### PR DESCRIPTION
Currently there will be an error when installing this extension in Contao 5.4 with `symfony/security-core` in version `7.x`:

```
Cannot autowire service "Markocupic\ContaoAltchaAntispam\DataContainer\FormField": argument "$security" of method   
   "__construct()" has type "Symfony\Component\Security\Core\Security" but this class was not found.
```

This PR fixes that by autowiring via the `AuthorizationCheckerInterface` instead (see also https://docs.contao.org/dev/reference/services/#security-helper).

This PR also adds the missing Symfony dependencies to the `composer.json`.