### PR TITLE
Remove `symfony/framework-bundle` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
         "markocupic/contao-twig-assets": "^1.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
-        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-foundation": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
         "symfony/routing": "^5.4 || ^6.4 || ^7.0",
-        "symfony/security-core": "^5.4 || ^6.4 || ^7.0"
+        "symfony/security-core": "^5.4 || ^6.4 || ^7.0",
+        "symfony/translations-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.12",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
         "symfony/routing": "^5.4 || ^6.4 || ^7.0",
         "symfony/security-core": "^5.4 || ^6.4 || ^7.0",
-        "symfony/translations-contracts": "^1.0 || ^2.0 || ^3.0"
+        "symfony/translation-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.12",

--- a/src/Controller/AltchaController.php
+++ b/src/Controller/AltchaController.php
@@ -16,12 +16,11 @@ namespace Markocupic\ContaoAltchaAntispam\Controller;
 
 use Markocupic\ContaoAltchaAntispam\Altcha;
 use Markocupic\ContaoAltchaAntispam\Exception\InvalidAlgorithmException;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(path: '/_contao_altcha_challenge', name: self::class)]
-class AltchaController extends AbstractController
+class AltchaController
 {
     public function __construct(
         private readonly Altcha $altcha,
@@ -33,6 +32,6 @@ class AltchaController extends AbstractController
      */
     public function __invoke(): JsonResponse
     {
-        return $this->json($this->altcha->createChallenge());
+        return new JsonResponse($this->altcha->createChallenge());
     }
 }


### PR DESCRIPTION
The `AltchaController` currently extends from the `AbstractController` of the `symfony/framework-bundle`. However, this isn't actually necessary. The `AltchaController` uses `$this->json()` from the `AbstractController` for the `JsonResponse`. But the result is already an array, and the `$this->json()` method is only a convenience function if you want to automatically serialize arbitrary data. None of that is needed here, so we can pass the array direktly to a new instance of `JsonResponse` instead, thus removing the dependency on `symfony/framework-bundle`.

I also added the missing dependency on `symfony/translation-contracts` here.